### PR TITLE
Update Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/Bubba8291/homebridge-sharkiq/issues"
   },
   "engines": {
-    "node": "^18.17.0",
-    "homebridge": "^1.6.0"
+    "homebridge": "^1.6.1",
+    "node": "^18.18.1 || ^20.8.0"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes anyone that is receiving this on node 20

```
The plugin "homebridge-sharkiq" requires Node.js version of ^18.17.0 which does not satisfy the current Node.js version of v20.8.0. You may need to upgrade your installation of Node.js - see https://homebridge.io/w/JTKEF
```